### PR TITLE
Fix k-fold CV

### DIFF
--- a/src/crossval.jl
+++ b/src/crossval.jl
@@ -104,8 +104,8 @@ function cross_validate(estfun::Function, evalfun::Function, n::Integer, gen, or
     best_inds = Int[]
     first = true
 
-    for train_inds in gen
-        test_inds = setdiff(1:n, train_inds)
+    for test_inds in gen
+        train_inds = setdiff(1:n, test_inds)
         model = estfun(train_inds)
         score = evalfun(model, test_inds)
         if first || lt(ord, best_score, score)


### PR DESCRIPTION
In k-fold cross-validation, the single subsample is used as the validation data for testing the model, and the remaining k − 1 subsamples are used for training.
