### PR TITLE
Add StratifiedKfold and StratifiedRandomSub

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,18 @@ This package implements several cross validation schemes: ``Kfold``, ``LOOCV``, 
      [4,5,8,9]
      [3,6,10]
     ```
+- **StratifiedKfold**(strata, k)
+
+    Like ``Kfold``, but indexes in each strata (defined by unique values of an iterator `strata`) are distributed approximately equally across the ``k`` folds.
+    Each strata should have at least ``k`` members.
+
+    ```julia
+    julia> collect(StratifiedKfold([:a, :a, :a, :b, :b, :c, :c, :a, :b, :c], 3))
+    3-element Array{Any,1}:
+     [1,2,4,6,8,9,10]
+     [3,4,5,7,8,10]
+     [1,2,3,5,6,7,9]
+    ```
 
 - **LOOCV**(n)
 
@@ -218,6 +230,22 @@ This package implements several cross validation schemes: ``Kfold``, ``LOOCV``, 
      [2,5,7,8,10]
      [1,3,5,6,7] 
     ``` 
+
+- **StratifiedRandomSum**(strata, sn, k)
+
+    Like ``RandomSub``,  but indexes in each strata (defined by unique values of an iterator `strata`) are distributed approximately equally across the ``k`` subsets.
+    ``sn`` should be greater than the number of strata, so that each stratum can be represented in each subset.
+
+    ```julia
+    julia> collect(StratifiedRandomSub([:a, :a, :a, :b, :b, :c, :c, :a, :b, :c], 7, 5))
+    5-element Array{Any,1}:
+     [1,2,3,4,6,7,9]
+     [1,3,4,6,8,9,10]
+     [1,3,5,7,8,9,10]
+     [1,2,4,7,8,9,10]
+     [1,2,3,4,5,6,10]
+    ```
+
 
 The package also provides a function ``cross_validate`` as below to run a cross validation procedure.
 

--- a/src/MLBase.jl
+++ b/src/MLBase.jl
@@ -52,8 +52,10 @@ module MLBase
     # crossval
     CrossValGenerator,  # abstract base class for all cross-validation plans
     Kfold,              # K-fold cross validation plan
+    StratifiedKfold,        # stratified K-fold cross validation plan
     LOOCV,              # leave-one-out cross validation plan
-    RandomSub,          # repetitive random subsampling cross validation
+    RandomSub,              # repeated random subsampling cross validation
+    StratifiedRandomSub,    # stratified repeated random subsampling
 
     cross_validate,     # perform cross-validation
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -123,3 +123,21 @@ function countne(a::IntegerVector, b::IntegerVector)
     return c
 end
 
+
+## return the unique values of A and a vector of vectors of indexes to reconstruct
+## the original array
+
+function unique_inverse(A::AbstractArray)
+    out = Array(eltype(A),0)
+    out_idx = Array(Vector{Int}, 0)
+    seen = Dict{eltype(A), Int}()
+    for (idx, x) in enumerate(A)
+        if !in(x, keys(seen))
+            seen[x] = length(seen) + 1
+            push!(out, x)
+            push!(out_idx, Int[])
+        end
+        push!(out_idx[seen[x]], idx)
+    end
+    out, out_idx
+end

--- a/test/crossval.jl
+++ b/test/crossval.jl
@@ -1,4 +1,3 @@
-
 using MLBase
 using Base.Test
 
@@ -12,6 +11,19 @@ for i = 1:3
 end
 x = vcat(ss...)
 @test sort(x) == [1:12]
+
+##StratifiedKfold
+
+strat = [:a, :a, :b, :b, :c, :c, :b, :c, :a]
+@test_throws ErrorException StratifiedKfold(strat, 4)
+ss = collect(StratifiedKfold(strat, 3))
+for i in 1:2
+    @test isa(ss[i], Vector{Int})
+	@test issorted(ss[i])
+    @test length(unique(strat[ss[i]])) == 3
+end
+x = vcat(map(s -> setdiff(1:9, s), ss)...)
+@test sort(x) == [1:9]
 
 ## LOOCV
 
@@ -35,3 +47,15 @@ ss = collect(LOOCV(4))
 # 	@test length(unique(ss[i])) == 5
 # end
 
+## StratifiedRandomSum
+
+strat =  [:a, :a, :b, :b, :c, :c, :b, :c, :a]
+@test_throws ErrorException StratifiedRandomSub(strat, 2, 10)
+ss = collect(StratifiedRandomSub(strat, 6, 10))
+@test length(ss) == 10
+@test all(map(length, ss) .== 6)
+
+#make sure small strata are (probably) always represented
+strat = push!(repeach([:a], 100), :b)
+ss = collect(StratifiedRandomSub(strat, 4, 100))
+@test all(map(s -> :b ∈ strat[s], ss))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -28,3 +28,12 @@ b = [1, 3, 3, 4, 6, 7, 8]
 
 @test counteq(a, b) == 3
 @test countne(a, b) == 4
+
+
+# unique_inverse
+a = [:a, :a, :b, :c, :b, :a]
+ui = MLBase.unique_inverse(a)
+@test isa(ui, (Vector{Symbol}, Vector{Vector{Int}}))
+b = Array(Symbol, mapreduce(length, +, ui[2]))
+for (obj, idx) in zip(ui...) b[idx] = obj end
+@test a == b


### PR DESCRIPTION
I also added `unique_inverse` in `utils.jl` which returns a vector of unique elements of an array and a vector of vectors of their indexes, but did not export it. 

Note that the way `StratifiedKfold` works is not consistent with `Kfold` in master right now, but is consistent with `Kfold` in the pull request in #5. That is, if #5 is merged, `Kfold(n, k)` and `StratifiedKfold(fill(1, n), k)` will do the same thing. 
