### PR TITLE
remove typing from unique_inverse

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -127,7 +127,7 @@ end
 ## return the unique values of A and a vector of vectors of indexes to reconstruct
 ## the original array
 
-function unique_inverse(A::AbstractArray)
+function unique_inverse(A)
     out = Array(eltype(A),0)
     out_idx = Array(Vector{Int}, 0)
     seen = Dict{eltype(A), Int}()


### PR DESCRIPTION
I added a type constraint to `unique_inverse` unnecessarily. Removing it allows any iterator to define strata for stratified cv.
