### PR TITLE
Transforms type hierarchy change for additional implementations

### DIFF
--- a/src/MLBase.jl
+++ b/src/MLBase.jl
@@ -26,16 +26,18 @@ module MLBase
     countne,        # count the number of non-equal pairs
 
     # datapre
-    Standardize,    # the type to represent a standardizing transform
+    Standardize,    # the type to represent a abstract standardizing transform
+    ZScore,         # the type to represent a z-score standardizing transform
+    MinMax,         # the type to represent a minmax standardizing transform
 
     indim,          # input dimension of a transform
-    outdim,         # output dimension of a transform 
+    outdim,         # output dimension of a transform
     estimate,       # estimate a model or transformation
     transform,      # apply a transformation to data
     transform!,     # apply a transformation to data in place
     standardize,    # estimate and apply a standardization
     standardize!,   # estimate and apply a standardization in place
-        
+
     # classification
     LabelMap,       # a type to represent a label map
 

--- a/src/datapre.jl
+++ b/src/datapre.jl
@@ -3,12 +3,33 @@
 
 ### Standardization
 
-immutable Standardize
+abstract Standardize
+
+transform!{T<:FloatingPoint, S<:Standardize}(t::S, x::DenseArray{T,1}) = transform!(x, t, x)
+transform!{T<:FloatingPoint, S<:Standardize}(t::S, x::DenseArray{T,2}) = transform!(x, t, x)
+
+transform{T<:Real, S<:Standardize}(t::S, x::DenseArray{T,1}) = transform!(Array(Float64, size(x)), t, x)
+transform{T<:Real, S<:Standardize}(t::S, x::DenseArray{T,2}) = transform!(Array(Float64, size(x)), t, x)
+
+function standardize{T<:Real, S<:Standardize}(::Type{S}, X::DenseArray{T,2}; args...)
+    t = estimate(S, X; args...)
+    Y = transform(t, X)
+    return (Y, t)
+end
+
+function standardize!{T<:Real, S<:Standardize}(::Type{S}, X::DenseArray{T,2}; args...)
+    t = estimate(S, X; args...)
+    Y = transform!(t, X)
+    return (Y, t)
+end
+
+# z-score
+immutable ZScore <: Standardize
     dim::Int
     mean::Vector{Float64}
     scale::Vector{Float64}
 
-    function Standardize(d::Int, m::Vector{Float64}, s::Vector{Float64})
+    function ZScore(d::Int, m::Vector{Float64}, s::Vector{Float64})
         lenm = length(m)
         lens = length(s)
         lenm == d || lenm == 0 || throw(DimensionMismatch("Inconsistent dimensions."))
@@ -17,10 +38,10 @@ immutable Standardize
     end
 end
 
-indim(t::Standardize) = t.dim
-outdim(t::Standardize) = t.dim
+indim(t::ZScore) = t.dim
+outdim(t::ZScore) = t.dim
 
-function transform!{YT<:Real,XT<:Real}(y::DenseArray{YT,1}, t::Standardize, x::DenseArray{XT,1})
+function transform!{YT<:Real,XT<:Real}(y::DenseArray{YT,1}, t::ZScore, x::DenseArray{XT,1})
     d = t.dim
     length(x) == length(y) == d || throw(DimensionMismatch("Inconsistent dimensions."))
 
@@ -51,7 +72,7 @@ function transform!{YT<:Real,XT<:Real}(y::DenseArray{YT,1}, t::Standardize, x::D
     return y
 end
 
-function transform!{YT<:Real,XT<:Real}(y::DenseArray{YT,2}, t::Standardize, x::DenseArray{XT,2})
+function transform!{YT<:Real,XT<:Real}(y::DenseArray{YT,2}, t::ZScore, x::DenseArray{XT,2})
     d = t.dim
     size(x,1) == size(y,1) == d || throw(DimensionMismatch("Inconsistent dimensions."))
     n = size(x,2)
@@ -96,22 +117,24 @@ function transform!{YT<:Real,XT<:Real}(y::DenseArray{YT,2}, t::Standardize, x::D
     return y
 end
 
-transform!{T<:FloatingPoint}(t::Standardize, x::DenseArray{T,1}) = transform!(x, t, x)
-transform!{T<:FloatingPoint}(t::Standardize, x::DenseArray{T,2}) = transform!(x, t, x)
-
-transform{T<:Real}(t::Standardize, x::DenseArray{T,1}) = transform!(Array(Float64, size(x)), t, x)
-transform{T<:Real}(t::Standardize, x::DenseArray{T,2}) = transform!(Array(Float64, size(x)), t, x)
-
 # estimate a standardize transform
-
-function estimate{T<:Real}(::Type{Standardize}, X::DenseArray{T,2}; center::Bool=true, scale::Bool=true)
+function estimate{T<:Real}(::Type{ZScore}, X::DenseArray{T,2}; args...)
     d, n = size(X)
     n >= 2 || error("X must contain at least two columns.")
 
+    center=true
+    scale=true
+    for (k,v) in args
+        if k == :center
+            center = v
+        elseif k == :scale
+            scale = v
+        end
+    end
     m = Array(Float64, ifelse(center, d, 0))
     s = Array(Float64, ifelse(scale, d, 0))
 
-    if center 
+    if center
         fill!(m, 0.0)
         for j = 1:n
             xj = view(X, :, j)
@@ -144,20 +167,61 @@ function estimate{T<:Real}(::Type{Standardize}, X::DenseArray{T,2}; center::Bool
         end
     end
 
-    return Standardize(d, m, s)
+    return ZScore(d, m, s)
 end
 
-# standardize
+# MinMax normalization
 
-function standardize{T<:Real}(X::DenseArray{T,2}; center::Bool=true, scale::Bool=true)
-    t = estimate(Standardize, X; center=center, scale=scale)
-    Y = transform(t, X)
-    return (Y, t)
+immutable MinMax  <: Standardize
+    dim::Int
+    min::Vector{Float64}
+    max::Vector{Float64}
+
+    function MinMax(d::Int, min::Vector{Float64}, max::Vector{Float64})
+        lenmin = length(min)
+        lenmax = length(max)
+        lenmin == d || lenmin == 0 || throw(DimensionMismatch("Inconsistent dimensions."))
+        lenmax == d || lenmax == 0 || throw(DimensionMismatch("Inconsistent dimensions."))
+        new(d, min, max)
+    end
 end
 
-function standardize!{T<:FloatingPoint}(X::DenseArray{T,2}; center::Bool=true, scale::Bool=true)
-    t = estimate(Standardize, X; center=center, scale=scale)
-    Y = transform!(t, X)
-    return (Y, t)
+indim(t::MinMax) = t.dim
+outdim(t::MinMax) = t.dim
+
+function estimate{T<:Real}(::Type{MinMax}, X::DenseArray{T,2}; args...)
+    d, n = size(X)
+    xmin, xmax = foldl(
+        (v,e)-> begin
+            push!(v[1], e[1])
+            push!(v[2], e[2])
+            v
+        end, (Float64[], Float64[]), mapslices(extrema, X, 2))
+    return MinMax(d, xmin, xmax)
 end
 
+function transform!{YT<:Real,XT<:Real}(y::DenseArray{YT,1}, t::MinMax, x::DenseArray{XT,1})
+    d = t.dim
+    length(x) == length(y) == d || throw(DimensionMismatch("Inconsistent dimensions."))
+
+    for i = 1:d
+        @inbounds y[i] = (x[i] - t.min[i]) / t.max[i]
+    end
+    return y
+end
+
+function transform!{YT<:Real,XT<:Real}(y::DenseArray{YT,2}, t::MinMax, x::DenseArray{XT,2})
+    d = t.dim
+    size(x,1) == size(y,1) == d || throw(DimensionMismatch("Inconsistent dimensions."))
+    n = size(x,2)
+    size(y,2) == n || throw(DimensionMismatch("Inconsistent dimensions."))
+
+    for j = 1:n
+        xj = view(x, :, j)
+        yj = view(y, :, j)
+        for i = 1:d
+            @inbounds yj[i] = (xj[i] - t.min[i]) / t.max[i]
+        end
+    end
+    return y
+end

--- a/test/datapre.jl
+++ b/test/datapre.jl
@@ -1,4 +1,3 @@
-
 using MLBase
 using Base.Test
 
@@ -6,14 +5,14 @@ using Base.Test
 
 X = rand(5, 8)
 
-(Y, t) = standardize(X; center=false, scale=false)
+(Y, t) = standardize(ZScore, X; center=false, scale=false)
 @test isa(t, Standardize)
 @test isempty(t.mean)
 @test isempty(t.scale)
 @test isequal(X, Y)
 @test_approx_eq transform(t, X[:,1]) Y[:,1]
 
-(Y, t) = standardize(X; center=false, scale=true)
+(Y, t) = standardize(ZScore, X; center=false, scale=true)
 @test isa(t, Standardize)
 @test isempty(t.mean)
 @test length(t.scale) == 5
@@ -21,16 +20,22 @@ s = sqrt(sum(abs2(X), 2) ./ (8 - 1))
 @test_approx_eq Y X ./ s
 @test_approx_eq transform(t, X[:,1]) Y[:,1]
 
-(Y, t) = standardize(X; center=true, scale=false)
+(Y, t) = standardize(ZScore, X; center=true, scale=false)
 @test isa(t, Standardize)
 @test length(t.mean) == 5
 @test isempty(t.scale)
 @test_approx_eq Y X .- mean(X, 2)
 @test_approx_eq transform(t, X[:,1]) Y[:,1]
 
-(Y, t) = standardize(X; center=true, scale=true)
+(Y, t) = standardize(ZScore, X; center=true, scale=true)
 @test isa(t, Standardize)
 @test length(t.mean) == 5
 @test length(t.scale) == 5
 @test_approx_eq Y (X .- mean(X, 2)) ./ std(X, 2)
+@test_approx_eq transform(t, X[:,1]) Y[:,1]
+
+(Y, t) = standardize(MinMax, X)
+@test length(t.min) == 5
+@test length(t.max) == 5
+@test_approx_eq Y (X .- minimum(X, 2)) ./ maximum(X, 2)
 @test_approx_eq transform(t, X[:,1]) Y[:,1]


### PR DESCRIPTION
I changed transforms type hierarchy and implemented `MinMax` normalization. The Z-score normalization related type was renamed from `Standardize` to `ZScore`.
