### PR TITLE
add common class encodings as wrapper for labelmap

### DIFF
--- a/src/MLBase.jl
+++ b/src/MLBase.jl
@@ -17,10 +17,10 @@ module MLBase
     Forward, Reverse,
 
     # utils
-    repeach,        # repeat each element in a vector 
+    repeach,        # repeat each element in a vector
     repeachcol,     # repeat each column in a matrix
     repeachrow,     # repeat each row in a matrix
-        
+
     # classification
     LabelMap,       # a type to represent a label map
 
@@ -33,6 +33,15 @@ module MLBase
     labelencode,    # encode a sequence of discrete values using a label map
     labeldecode,    # decode the label to the associated discrete value
     groupindices,   # grouped indices based on labels
+    classDistribution, # computes the number of observations per class
+    ClassEncoding,  # abstract base class representing a class encoding
+    BinaryClassEncoding,      # abstract base class for all binary class encodings
+    MultinomialClassEncoding, # abstract base class for all binary class encodings
+    ZeroOneClassEncoding,     # class encoding to for {0, 1}
+    SignedClassEncoding,      # class encoding to for {-1, 1}
+    MultivalueClassEncoding,  # class encoding to for 1:k or 0:k-1
+    OneOfKClassEncoding,      # class encoding to one-out-of-k
+    OneHotClassEncoding,      # Typealias for one-out-of-k encoding
 
     # crossval
     CrossValGenerator,  # abstract base class for all cross-validation plans
@@ -54,11 +63,11 @@ module MLBase
     hitrate,        # compute hit-rate of ranked lists at a specific rank
     hitrates,       # compute hit-rate of ranked lists at multiple ranks
     roc,            # compute roc numbers from predictions
-    true_positive,      # number of true positives 
-    true_negative,      # number of true negatives 
+    true_positive,      # number of true positives
+    true_negative,      # number of true negatives
     false_positive,     # number of false positives
     false_negative,     # number of false negatives
-    true_positive_rate,     # rate of true positives 
+    true_positive_rate,     # rate of true positives
     true_negative_rate,     # rate of true negatives
     false_positive_rate,    # rate of false positives
     false_negative_rate,    # rate of false negatives
@@ -76,7 +85,7 @@ module MLBase
     include("crossval.jl")
     include("perfeval.jl")
     include("modeltune.jl")
-    
+
     include("deprecates.jl")
 end
 

--- a/src/classification.jl
+++ b/src/classification.jl
@@ -65,7 +65,7 @@ function classify_withscores!(r::IntegerVector, s::RealVector, x::RealMatrix, or
     return (r, s)
 end
 
-classify_withscores!(r::IntegerVector, s::RealVector, x::RealMatrix) = 
+classify_withscores!(r::IntegerVector, s::RealVector, x::RealMatrix) =
     classify_withscores!(r, s, x, Forward)
 
 function classify_withscores{T<:Real}(x::RealMatrix{T}, ord::Ordering)
@@ -80,7 +80,7 @@ classify_withscores{T<:Real}(x::RealMatrix{T}) = classify_withscores(x, Forward)
 
 # classify with threshold
 
-classify(x::RealVector, t::Real, ord::Ordering) = 
+classify(x::RealVector, t::Real, ord::Ordering) =
     ((k, v) = classify_withscore(x, ord); ifelse(lt(ord, v, t), 0, k))
 
 classify(x::RealVector, t::Real) = classify(x, t, Forward)
@@ -98,7 +98,7 @@ end
 classify!(r::IntegerVector, x::RealMatrix, t::Real) = classify!(r, x, t, Forward)
 
 classify(x::RealMatrix, t::Real, ord::Ordering) = classify!(Array(Int, size(x,2)), x, t, ord)
-classify(x::RealMatrix, t::Real) = classify(x, t, Forward)  
+classify(x::RealMatrix, t::Real) = classify(x, t, Forward)
 
 
 ## label map
@@ -139,15 +139,183 @@ function labelmap{T}(xs::AbstractArray{T})
     return LabelMap(vs, v2i)
 end
 
+
+## class encodings
+
+abstract ClassEncoding
+abstract BinaryClassEncoding <: ClassEncoding
+abstract MultinomialClassEncoding <: ClassEncoding
+
+## binary class encodings
+
+immutable ZeroOneClassEncoding{T} <: BinaryClassEncoding
+  labelmap::LabelMap{T}
+
+  function ZeroOneClassEncoding(labelmap::LabelMap{T})
+    numLabels = length(labelmap.vs)
+    if numLabels != 2
+      throw(ArgumentError("The given target vector must have exactly two classes"))
+    end
+    new(labelmap)
+  end
+end
+
+ZeroOneClassEncoding{T}(targets::Vector{T}) =
+  ZeroOneClassEncoding{T}(labelmap(targets))
+
+immutable SignedClassEncoding{T} <: BinaryClassEncoding
+  labelmap::LabelMap{T}
+
+  function SignedClassEncoding(labelmap::LabelMap{T})
+    numLabels = length(labelmap.vs)
+    if numLabels != 2
+      throw(ArgumentError("The given target vector must have exactly two classes"))
+    end
+    new(labelmap)
+  end
+end
+
+SignedClassEncoding{T}(targets::Vector{T}) =
+  SignedClassEncoding{T}(labelmap(targets))
+
+## multinomial class encodings
+
+immutable MultivalueClassEncoding{T} <: MultinomialClassEncoding
+  labelmap::LabelMap{T}
+  nlabels::Int
+  zeroBased::Bool
+
+  function MultivalueClassEncoding(labelmap::LabelMap{T}, zeroBased = false)
+    numLabels = length(labelmap.vs)
+    if numLabels < 2
+      throw(ArgumentError("The given target vector has less than two classes"))
+    end
+    new(labelmap, numLabels, zeroBased)
+  end
+end
+
+MultivalueClassEncoding{T}(targets::Vector{T}; zero_based = false) =
+  MultivalueClassEncoding{T}(labelmap(targets), zero_based)
+
+immutable OneOfKClassEncoding{T} <: MultinomialClassEncoding
+  labelmap::LabelMap{T}
+  nlabels::Int
+
+  function OneOfKClassEncoding(labelmap::LabelMap{T})
+    numLabels = length(labelmap.vs)
+    if numLabels < 2
+      throw(ArgumentError("The given target vector has less than two classes"))
+    end
+    new(labelmap, numLabels)
+  end
+end
+
+OneOfKClassEncoding{T}(targets::Vector{T}) =
+  OneOfKClassEncoding{T}(labelmap(targets))
+
+typealias OneHotClassEncoding OneOfKClassEncoding
+
+## display class encodings
+
+function getLabelString{T}(labelmap::LabelMap{T})
+  labels = labelmap.vs
+  c = length(labels)
+  if c > 10
+    labels = labels[1:10]
+    labelString = string(join(labels, ", "), ", ... [TRUNC]")
+  else
+    labelString = join(labels, ", ")
+  end
+end
+
+function show{T}(io::IO, classEncoding::ZeroOneClassEncoding{T})
+  labelString = getLabelString(classEncoding.labelmap)
+  print(io,
+        """
+        ZeroOneClassEncoding (Binary) to {0, 1}
+          .labelmap  ...  encoding for: {$labelString}""")
+end
+
+function show{T}(io::IO, classEncoding::SignedClassEncoding{T})
+  labelString = getLabelString(classEncoding.labelmap)
+  print(io,
+        """
+        SignedClassEncoding (Binary) to {-1, 1}
+          .labelmap  ...  encoding for: {$labelString}""")
+end
+
+function show{T}(io::IO, classEncoding::MultivalueClassEncoding{T})
+  c = classEncoding.nlabels
+  zB = classEncoding.zeroBased
+  labelString = getLabelString(classEncoding.labelmap)
+  print(io,
+        """
+        MultivalueClassEncoding (Multinomial) to range $((1:c) - zB*1)
+          .nlabels   ...  $c classes
+          .labelmap  ...  encoding for: {$labelString}""")
+end
+
+function show{T}(io::IO, classEncoding::OneOfKClassEncoding{T})
+  c = classEncoding.nlabels
+  labelString = getLabelString(classEncoding.labelmap)
+  print(io,
+        """
+        OneOfKClassEncoding (Multinomial) to one-out-of-$c hot-vector
+          .nlabels   ...  $c classes
+          .labelmap  ...  encoding for: {$labelString}""")
+end
+
+
 # use a map to encode discrete values into labels
 labelencode{T}(lmap::LabelMap{T}, x) = lmap.v2i[convert(T, x)]
-labelencode{T}(lmap::LabelMap{T}, xs::AbstractArray{T}) = 
+labelencode{T}(lmap::LabelMap{T}, xs::AbstractArray{T}) =
     reshape(Int[labelencode(lmap, x) for x in xs], size(xs))
 
 # decode the label to the associated discrete value
 labeldecode{T}(lmap::LabelMap{T}, y::Int) = lmap.vs[y]
-labeldecode{T}(lmap::LabelMap{T}, ys::AbstractArray{Int}) = 
+labeldecode{T}(lmap::LabelMap{T}, ys::AbstractArray{Int}) =
     reshape(T[labeldecode(lmap, y) for y in ys], size(ys))
+
+# encoding and decoding the labels for class encodings
+function labelencode{T}(classEncoding::ZeroOneClassEncoding{T}, targets::Vector{T})
+  indicies = labelencode(classEncoding.labelmap, targets)
+  indicies - 1
+end
+
+function labeldecode{T}(classEncoding::ZeroOneClassEncoding{T}, values::Vector{Int})
+  indicies = values + 1
+  labeldecode(classEncoding.labelmap, indicies)
+end
+
+function labelencode{T}(classEncoding::SignedClassEncoding{T}, targets::Vector{T})
+  indicies = labelencode(classEncoding.labelmap, targets)
+  iround(indicies - 1.5)
+end
+
+function labeldecode{T}(classEncoding::SignedClassEncoding{T}, values::Vector{Int})
+  indicies = iround((values / 2.) + 1.5)
+  labeldecode(classEncoding.labelmap, indicies)
+end
+
+function labelencode{T}(classEncoding::MultivalueClassEncoding{T}, targets::Vector{T})
+  labelencode(classEncoding.labelmap, targets) - classEncoding.zeroBased*1
+end
+
+function labeldecode{T}(classEncoding::MultivalueClassEncoding{T}, values::Vector{Int})
+  labeldecode(classEncoding.labelmap, values + classEncoding.zeroBased*1)
+end
+
+function labelencode{T}(classEncoding::OneOfKClassEncoding{T}, targets::Vector{T})
+  indicies = labelencode(classEncoding.labelmap, targets)
+  convert(Matrix{Int}, indicatormat(indicies))'
+end
+
+function labeldecode{T}(classEncoding::OneOfKClassEncoding{T}, values::Matrix{Int})
+  numLabels = classEncoding.nlabels
+  indicies = convert(Vector{Int}, values * [1:numLabels])
+  labeldecode(classEncoding.labelmap, indicies)
+end
+
 
 ## group labels
 
@@ -186,3 +354,13 @@ function groupindices{T}(lmap::LabelMap{T}, xs::AbstractArray{T})
     return gs
 end
 
+function groupindices{T}(classEncoding::ClassEncoding, targets::Vector{T})
+  groupindices(classEncoding.labelmap, targets)
+end
+
+
+# class distribution
+
+function classDistribution{T}(classEncoding::ClassEncoding, targets::Vector{T})
+  classEncoding.labelmap.vs, map(length,groupindices(classEncoding, targets))
+end

--- a/src/classification.jl
+++ b/src/classification.jl
@@ -289,11 +289,11 @@ end
 
 function labelencode{T}(classEncoding::SignedClassEncoding{T}, targets::Vector{T})
   indicies = labelencode(classEncoding.labelmap, targets)
-  iround(indicies - 1.5)
+  round(Integer,2(indicies - 1.5))
 end
 
 function labeldecode{T}(classEncoding::SignedClassEncoding{T}, values::Vector{Int})
-  indicies = iround((values / 2.) + 1.5)
+  indicies = round(Integer,(values / 2.) + 1.5)
   labeldecode(classEncoding.labelmap, indicies)
 end
 
@@ -312,7 +312,7 @@ end
 
 function labeldecode{T}(classEncoding::OneOfKClassEncoding{T}, values::Matrix{Int})
   numLabels = classEncoding.nlabels
-  indicies = convert(Vector{Int}, values * [1:numLabels])
+  indicies = convert(Vector{Int}, values * collect(1:numLabels))
   labeldecode(classEncoding.labelmap, indicies)
 end
 

--- a/test/classification.jl
+++ b/test/classification.jl
@@ -63,3 +63,109 @@ gs = Any[[1,2,5,8],[3,4,6],[7]]
 @test groupindices(3, labels) == gs
 @test groupindices(lmap, xs) == gs
 
+# class encodings
+
+@test BinaryClassEncoding <: ClassEncoding
+@test ZeroOneClassEncoding <: BinaryClassEncoding
+@test SignedClassEncoding <: BinaryClassEncoding
+
+wrongDim1 = ["y","y","y"]
+wrongDim2 = ["y","n","c"]
+
+@test_throws ArgumentError ZeroOneClassEncoding(wrongDim1)
+@test_throws ArgumentError ZeroOneClassEncoding(wrongDim2)
+@test_throws ArgumentError SignedClassEncoding(wrongDim1)
+@test_throws ArgumentError SignedClassEncoding(wrongDim2)
+
+t = ["y", "n", "n", "y", "n"]
+wrongLabel1 = ["a","b","a"]
+wrongLabel2 = [1,2,2]
+
+ce = ZeroOneClassEncoding(t)
+@test_throws KeyError labelencode(ce, wrongLabel1)
+@test_throws MethodError labelencode(ce, wrongLabel2)
+
+ce = SignedClassEncoding(t)
+@test_throws KeyError labelencode(ce, wrongLabel1)
+@test_throws MethodError labelencode(ce, wrongLabel2)
+
+
+t = ["y", "n", "n", "y", "n"]
+y = ["n","y", "y", "n"]
+
+ce = ZeroOneClassEncoding(t)
+pred = labelencode(ce, y)
+idx = groupindices(ce, t)
+@test idx[1] == [1,4]
+@test idx[2] == [2,3,5]
+@test classDistribution(ce, t) == (["y","n"], [2, 3])
+@test pred == [1, 0, 0, 1]
+@test labeldecode(ce, pred) == y
+@test labeldecode(ce, convert(Vector{Int},pred)) == y
+
+ce = SignedClassEncoding(t)
+pred = labelencode(ce, y)
+idx = groupindices(ce, t)
+@test idx[1] == [1,4]
+@test idx[2] == [2,3,5]
+@test classDistribution(ce, t) == (["y","n"], [2, 3])
+@test pred == [1, -1, -1, 1]
+@test labeldecode(ce, pred) == y
+@test labeldecode(ce, convert(Vector{Int},pred)) == y
+
+
+@test MultinomialClassEncoding <: ClassEncoding
+@test MultivalueClassEncoding <: MultinomialClassEncoding
+@test OneOfKClassEncoding <: MultinomialClassEncoding
+@test OneHotClassEncoding <: MultinomialClassEncoding
+@test OneHotClassEncoding == OneOfKClassEncoding
+
+wrongDim1 = ["y","y","y"]
+
+@test_throws ArgumentError MultivalueClassEncoding(wrongDim1)
+@test_throws ArgumentError OneOfKClassEncoding(wrongDim1)
+
+t = ["y", "n", "k", "y", "n"]
+wrongLabel1 = ["a","b","a"]
+wrongLabel2 = [1,2,2]
+
+ce = MultivalueClassEncoding(t)
+@test_throws KeyError labelencode(ce, wrongLabel1)
+@test_throws MethodError labelencode(ce, wrongLabel2)
+
+ce = OneOfKClassEncoding(t)
+@test_throws KeyError labelencode(ce, wrongLabel1)
+@test_throws MethodError labelencode(ce, wrongLabel2)
+
+t = ["y", "n", "k", "y", "n"]
+y = ["n", "y", "y", "k", "n"]
+
+ce = MultivalueClassEncoding(t)
+pred = labelencode(ce, y)
+idx = groupindices(ce, t)
+@test idx[1] == [1,4]
+@test idx[2] == [2,5]
+@test idx[3] == [3]
+@test classDistribution(ce, t) == (["y","n","k"], [2, 2, 1])
+@test pred == [2, 1, 1, 3, 2]
+@test labeldecode(ce, pred) == y
+
+ce = MultivalueClassEncoding(t, zero_based=true)
+pred = labelencode(ce, y)
+idx = groupindices(ce, t)
+@test idx[1] == [1,4]
+@test idx[2] == [2,5]
+@test idx[3] == [3]
+@test classDistribution(ce, t) == (["y","n","k"], [2, 2, 1])
+@test pred == [1, 0, 0, 2, 1]
+@test labeldecode(ce, pred) == y
+
+ce = OneOfKClassEncoding(t)
+pred = labelencode(ce, y)
+@test pred ==
+  [0  1  0;
+   1  0  0;
+   1  0  0;
+   0  0  1;
+   0  1  0]
+@test labeldecode(ce, pred) == y


### PR DESCRIPTION
I am tinkering on a package where I need these and I though these classes would be a better fit here.
I included the tests as well. If there is interest I will also adapt the documentation accordingly.

I included these encodings as wrappers around labelmap: 
* `ZeroOneClassEncoding`: {0,1}
* `SignedClassEncoding`: {-1,1}
* `OneOfKClassEncoding`: see below
* `MultinomialClassEncoding`: {1:k}, or {0:k-1}

It allows you to do things like

```
t = ["y", "n", "k", "y"]
y = ["n", "y", "y", "k", "n"]

encoding = OneOfKClassEncoding(t)
pred = labelencode(encoding, y)
```
where the `pred` would end up being

``` 
@test pred ==
  [0  1  0;
   1  0  0;
   1  0  0;
   0  0  1;
   0  1  0]
```

and of course `labeldecode` would bring you back to the input

```
@test labeldecode(encoding, pred) == y
```

let me know what you think.