### PR TITLE
Add link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Swiss knife for machine learning.
 [![Build Status](https://travis-ci.org/JuliaStats/MLBase.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/MLBase.jl)
 [![MLBase](http://pkg.julialang.org/badges/MLBase_0.6.svg)](http://pkg.julialang.org/?pkg=MLBase)
 [![Coveralls](https://coveralls.io/repos/github/JuliaStats/MLBase.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaStats/MLBase.jl?branch=master)
+[![Documentation Status](https://readthedocs.org/projects/mlbasejl/badge/?version=latest)](http://mlbasejl.readthedocs.io/en/latest/?badge=latest)
 
 This package does not implement specific machine learning algorithms. Instead, it provides a collection of useful tools to support machine learning programs, including:
 


### PR DESCRIPTION
I always find it handy to have the link right there when I visit a page on github.