### PR TITLE
Control randomness of Kfold,StratifiedKfold,RandomSub

### DIFF
--- a/src/crossval.jl
+++ b/src/crossval.jl
@@ -99,15 +99,10 @@ end
 # Repeated random sub-sampling
 
 struct RandomSub <: CrossValGenerator
+    rng::AbstractRNG # Random number generator
     n::Int    # total length
     sn::Int   # length of each subset
     k::Int    # number of subsets
-    rng::AbstractRNG # Random number generator
-
-    function RandomSub(rng::AbstractRNG, n::Int, sn::Int, k::Int)
-        new(n, sn, k, rng)
-    end
-
 end
 
 RandomSub(n::Int, sn::Int, k::Int) = RandomSub(Random.GLOBAL_RNG, n::Int, sn::Int, k::Int)

--- a/src/crossval.jl
+++ b/src/crossval.jl
@@ -11,11 +11,13 @@ struct Kfold <: CrossValGenerator
     k::Int
     coeff::Float64
 
-    function Kfold(n::Int, k::Int, rng::AbstractRNG = MersenneTwister())
+    function Kfold(rng::AbstractRNG, n::Int, k::Int)
         2 <= k <= n || error("The value of k must be in [2, length(a)].")
         new(randperm(rng, n), k, n / k)
     end
 end
+
+Kfold(n::Int, k::Int) = Kfold(Random.GLOBAL_RNG, n, k)
 
 length(c::Kfold) = c.k
 
@@ -42,7 +44,7 @@ struct StratifiedKfold <: CrossValGenerator
     permseqs::Vector{Vector{Int}}  #Vectors of vectors of indexes for each stratum
     k::Int                         #Number of splits
     coeffs::Vector{Float64}        #About how many observations per strata are in a val set
-    function StratifiedKfold(strata, k, rng::AbstractRNG = MersenneTwister())
+    function StratifiedKfold(rng::AbstractRNG, strata, k)
         2 <= k <= length(strata) || error("The value of k must be in [2, length(strata)].")
         strata_labels, permseqs = unique_inverse(strata)
         map( s -> shuffle!(rng, s), permseqs)
@@ -54,6 +56,8 @@ struct StratifiedKfold <: CrossValGenerator
         new(length(strata), permseqs, k, coeffs)
     end
 end
+
+StratifiedKfold(strata, k) = StratifiedKfold(Random.GLOBAL_RNG, strata, k)
 
 length(c::StratifiedKfold) = c.k
 
@@ -100,11 +104,13 @@ struct RandomSub <: CrossValGenerator
     k::Int    # number of subsets
     rng::AbstractRNG # Random number generator
 
-    function RandomSub(n::Int, sn::Int, k::Int, rng::AbstractRNG = MersenneTwister())
+    function RandomSub(rng::AbstractRNG, n::Int, sn::Int, k::Int)
         new(n, sn, k, rng)
     end
 
 end
+
+RandomSub(n::Int, sn::Int, k::Int) = RandomSub(Random.GLOBAL_RNG, n::Int, sn::Int, k::Int)
 
 length(c::RandomSub) = c.k
 

--- a/test/crossval.jl
+++ b/test/crossval.jl
@@ -15,15 +15,16 @@ x = vcat(map(s -> setdiff(1:12, s), ss)...)
 
 
 # Verify that we are indeed controlling the random partitioning
-# by specifying in the third argument a random number generator.
+# by specifying in the first argument a random number generator.
 # The test involves calling Kfold with arbitrary chosen n,k pairs
 # for the same seed choice picked from an arbitrarily defined set.
+# Desired outcome is that for the same seed, we should get the same folds.
 
 for seed in [1, 101, 10101]
     for n in [20, 30, 31]
         for k in [2, 3, 7]
-            aux1 = collect(Kfold(n, k, MersenneTwister(seed)))
-            aux2 = collect(Kfold(n, k, MersenneTwister(seed)))
+            aux1 = collect(Kfold(MersenneTwister(seed), n, k))
+            aux2 = collect(Kfold(MersenneTwister(seed), n, k))
             @test aux1 == aux2  # folds must be the same
         end
     end
@@ -46,12 +47,13 @@ x = vcat(map(s -> setdiff(1:9, s), ss)...)
 
 
 # Verify that we are indeed controlling the random partitioning
-# by specifying in the third argument a random number generator.
+# by specifying in the first argument a random number generator.
 # Try this out for a few arbitrarily chosen random seeds.
+# Desired outcome is that for the same seed, we should get the same folds.
 
 for seed in [1, 101, 10101]
-    aux1 = collect(StratifiedKfold(strat, 3, MersenneTwister(seed)))
-    aux2 = collect(StratifiedKfold(strat, 3, MersenneTwister(seed)))
+    aux1 = collect(StratifiedKfold(MersenneTwister(seed), strat, 3))
+    aux2 = collect(StratifiedKfold(MersenneTwister(seed), strat, 3))
     @test aux1 == aux2  # folds must be the same
 end
 
@@ -82,17 +84,19 @@ end
 
 
 # Verify that we are indeed controlling the random partitioning
-# by specifying in the third argument a random number generator.
+# by specifying in the first argument a random number generator.
 # The test involves calling RandomSub with arbitrary chosen 
 # n,k,sn arguments for for the same seed choice picked from an
 # arbitrarily defined set.
+# Desired outcome is that for the same seed, we should get the 
+# same folds.
 
 for seed in [1, 101, 10101]
     for n in [20, 30, 31]
         for sn in [2, 7, 11]
             for k in [2, 3, 7]
-                aux1 = collect(RandomSub(n, k, sn, MersenneTwister(seed)))
-                aux2 = collect(RandomSub(n, k, sn, MersenneTwister(seed)))
+                aux1 = collect(RandomSub(MersenneTwister(seed), n, k, sn))
+                aux2 = collect(RandomSub(MersenneTwister(seed), n, k, sn))
                 @test aux1 == aux2  # folds must be the same
             end
         end

--- a/test/crossval.jl
+++ b/test/crossval.jl
@@ -1,4 +1,5 @@
 using MLBase
+using Random
 using Test
 
 ## Kfold
@@ -12,6 +13,24 @@ end
 x = vcat(map(s -> setdiff(1:12, s), ss)...)
 @test sort(x) == collect(1:12)
 
+
+# Verify that we are indeed controlling the random partitioning
+# by specifying in the third argument a random number generator.
+# The test involves calling Kfold with arbitrary chosen n,k pairs
+# for the same seed choice picked from an arbitrarily defined set.
+
+for seed in [1, 101, 10101]
+    for n in [20, 30, 31]
+        for k in [2, 3, 7]
+            aux1 = collect(Kfold(n, k, MersenneTwister(seed)))
+            aux2 = collect(Kfold(n, k, MersenneTwister(seed)))
+            @test aux1 == aux2  # folds must be the same
+        end
+    end
+end
+
+
+
 ## StratifiedKfold
 
 strat = [:a, :a, :b, :b, :c, :c, :b, :c, :a]
@@ -24,6 +43,18 @@ for i in 1:2
 end
 x = vcat(map(s -> setdiff(1:9, s), ss)...)
 @test sort(x) == collect(1:9)
+
+
+# Verify that we are indeed controlling the random partitioning
+# by specifying in the third argument a random number generator.
+# Try this out for a few arbitrarily chosen random seeds.
+
+for seed in [1, 101, 10101]
+    aux1 = collect(StratifiedKfold(strat, 3, MersenneTwister(seed)))
+    aux2 = collect(StratifiedKfold(strat, 3, MersenneTwister(seed)))
+    @test aux1 == aux2  # folds must be the same
+end
+
 
 ## LOOCV
 
@@ -48,6 +79,26 @@ for i = 1:6
     @test 1 <= minimum(ss[i]) <= maximum(ss[i]) <= 10
     @test length(unique(ss[i])) == 5
 end
+
+
+# Verify that we are indeed controlling the random partitioning
+# by specifying in the third argument a random number generator.
+# The test involves calling RandomSub with arbitrary chosen 
+# n,k,sn arguments for for the same seed choice picked from an
+# arbitrarily defined set.
+
+for seed in [1, 101, 10101]
+    for n in [20, 30, 31]
+        for sn in [2, 7, 11]
+            for k in [2, 3, 7]
+                aux1 = collect(RandomSub(n, k, sn, MersenneTwister(seed)))
+                aux2 = collect(RandomSub(n, k, sn, MersenneTwister(seed)))
+                @test aux1 == aux2  # folds must be the same
+            end
+        end
+    end
+end
+
 
 ## StratifiedRandomSub
 


### PR DESCRIPTION
I modified the code so that the randomness of `Kfold`, `StratifiedKfold` and `RandomSub` can be controlled. 

This is done by passing an optional object of type `AbstractRNG` via the new argument `rng`. 

The default value of the new argument `rng` is `MersenneTwister()`.

Example: `Kfold(10,2, MersenneTwister(1))`


I did not modify `StratifiedRandomSub` as I don't understand where random indices are samples.

I also did not modify `LOOCV` as there seems to be naturally no need for it.



Fixes #56