### PR TITLE
Upgrade to StatsBase v0.34

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,45 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if Julia is already available in the PATH
+        id: julia_in_path
+        run: which julia
+        continue-on-error: true
+      - name: Install Julia, but only if it is not already available in the PATH
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+          arch: ${{ runner.arch }}
+        if: steps.julia_in_path.outcome != 'success'
+      - name: "Add the General registry via Git"
+        run: |
+          import Pkg
+          ENV["JULIA_PKG_SERVER"] = ""
+          Pkg.Registry.add("General")
+        shell: julia --color=yes {0}
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "3"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+          # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "0.9.2"
 
 [deps]
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
-NumericalTypeAliases = "be9b823e-291e-41a1-b8ce-806204e78f92"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
@@ -12,7 +11,6 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 IterTools = "1"
 Reexport = "1"
-NumericalTypeAliases = "0.2"
 StatsBase = "0.34"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 IterTools = "1"
 Reexport = "1"
-StatsBase = "0.34"
+StatsBase = "0.33, 0.34"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "MLBase"
 uuid = "f0e99cf1-93fa-52ec-9ecc-5026115318e0"
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+NumericalTypeAliases = "be9b823e-291e-41a1-b8ce-806204e78f92"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
@@ -11,7 +12,8 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 IterTools = "1"
 Reexport = "1"
-StatsBase = "0.33"
+NumericalTypeAliases = "0.2"
+StatsBase = "0.34"
 julia = "1"
 
 [extras]

--- a/src/MLBase.jl
+++ b/src/MLBase.jl
@@ -8,7 +8,7 @@ module MLBase
     import Base: length, show, keys, precision, length, getindex
     import Base: iterate
     import Base.Order: lt, Ordering, ForwardOrdering, ReverseOrdering, Forward, Reverse
-    import StatsBase: RealVector, IntegerVector, RealMatrix, IntegerMatrix, RealArray
+    import NumericalTypeAliases: RealVector, IntegerVector, RealMatrix, IntegerMatrix, RealArray
     import IterTools: product
 
     export

--- a/src/MLBase.jl
+++ b/src/MLBase.jl
@@ -8,7 +8,6 @@ module MLBase
     import Base: length, show, keys, precision, length, getindex
     import Base: iterate
     import Base.Order: lt, Ordering, ForwardOrdering, ReverseOrdering, Forward, Reverse
-    import NumericalTypeAliases: RealVector, IntegerVector, RealMatrix, IntegerMatrix, RealArray
     import IterTools: product
 
     export

--- a/src/classification.jl
+++ b/src/classification.jl
@@ -4,7 +4,7 @@
 
 # classify
 
-function classify(x::RealVector, ord::Ordering)
+function classify(x::AbstractVector{<:Real}, ord::Ordering)
     n = length(x)
     v = x[1]
     k::Int = 1
@@ -18,9 +18,9 @@ function classify(x::RealVector, ord::Ordering)
     return k
 end
 
-classify(x::RealVector) = classify(x, Forward)
+classify(x::AbstractVector{<:Real}) = classify(x, Forward)
 
-function classify!(r::IntegerVector, x::RealMatrix, ord::Ordering)
+function classify!(r::AbstractVector{<:Integer}, x::AbstractMatrix{<:Real}, ord::Ordering)
     m = size(x, 1)
     n = size(x, 2)
     length(r) == n || throw(DimensionMismatch("Mismatched length of r."))
@@ -30,15 +30,15 @@ function classify!(r::IntegerVector, x::RealMatrix, ord::Ordering)
     return r
 end
 
-classify!(r::IntegerVector, x::RealMatrix) = classify!(r, x, Forward)
+classify!(r::AbstractVector{<:Integer}, x::AbstractMatrix{<:Real}) = classify!(r, x, Forward)
 
 # - this one throws a deprecation
-classify(x::RealMatrix, ord::Ordering) = classify!(Array{Int}(undef, size(x,2)), x, ord)
-classify(x::RealMatrix) = classify(x, Forward)
+classify(x::AbstractMatrix{<:Real}, ord::Ordering) = classify!(Array{Int}(undef, size(x,2)), x, ord)
+classify(x::AbstractMatrix{<:Real}) = classify(x, Forward)
 
 # classify with score(s)
 
-function classify_withscore(x::RealVector, ord::Ordering)
+function classify_withscore(x::AbstractVector{<:Real}, ord::Ordering)
     n = length(x)
     v = x[1]
     k::Int = 1
@@ -52,9 +52,9 @@ function classify_withscore(x::RealVector, ord::Ordering)
     return (k, v)
 end
 
-classify_withscore(x::RealVector) = classify_withscore(x, Forward)
+classify_withscore(x::AbstractVector{<:Real}) = classify_withscore(x, Forward)
 
-function classify_withscores!(r::IntegerVector, s::RealVector, x::RealMatrix, ord::Ordering)
+function classify_withscores!(r::AbstractVector{<:Integer}, s::AbstractVector{<:Real}, x::AbstractMatrix{<:Real}, ord::Ordering)
     m = size(x, 1)
     n = size(x, 2)
     length(r) == n || throw(DimensionMismatch("Mismatched length of r."))
@@ -66,27 +66,27 @@ function classify_withscores!(r::IntegerVector, s::RealVector, x::RealMatrix, or
     return (r, s)
 end
 
-classify_withscores!(r::IntegerVector, s::RealVector, x::RealMatrix) =
+classify_withscores!(r::AbstractVector{<:Integer}, s::AbstractVector{<:Real}, x::AbstractMatrix{<:Real}) =
     classify_withscores!(r, s, x, Forward)
 
-function classify_withscores(x::RealMatrix{T}, ord::Ordering) where T<:Real
+function classify_withscores(x::AbstractMatrix{<:Real}{T}, ord::Ordering) where T<:Real
     n = size(x, 2)
     r = Array{Int}(undef, n)
     s = Array{T}(undef, n)
     return classify_withscores!(r, s, x, ord)
 end
 
-classify_withscores(x::RealMatrix{T}) where {T<:Real} = classify_withscores(x, Forward)
+classify_withscores(x::AbstractMatrix{<:Real}{T}) where {T<:Real} = classify_withscores(x, Forward)
 
 
 # classify with threshold
 
-classify(x::RealVector, t::Real, ord::Ordering) =
+classify(x::AbstractVector{<:Real}, t::Real, ord::Ordering) =
     ((k, v) = classify_withscore(x, ord); ifelse(lt(ord, v, t), 0, k))
 
-classify(x::RealVector, t::Real) = classify(x, t, Forward)
+classify(x::AbstractVector{<:Real}, t::Real) = classify(x, t, Forward)
 
-function classify!(r::IntegerVector, x::RealMatrix, t::Real, ord::Ordering)
+function classify!(r::AbstractVector{<:Integer}, x::AbstractMatrix{<:Real}, t::Real, ord::Ordering)
     m = size(x, 1)
     n = size(x, 2)
     length(r) == n || throw(DimensionMismatch("Mismatched length of r."))
@@ -96,10 +96,10 @@ function classify!(r::IntegerVector, x::RealMatrix, t::Real, ord::Ordering)
     return r
 end
 
-classify!(r::IntegerVector, x::RealMatrix, t::Real) = classify!(r, x, t, Forward)
+classify!(r::AbstractVector{<:Integer}, x::AbstractMatrix{<:Real}, t::Real) = classify!(r, x, t, Forward)
 
-classify(x::RealMatrix, t::Real, ord::Ordering) = classify!(Array{Int}(undef, size(x,2)), x, t, ord)
-classify(x::RealMatrix, t::Real) = classify(x, t, Forward)
+classify(x::AbstractMatrix{<:Real}, t::Real, ord::Ordering) = classify!(Array{Int}(undef, size(x,2)), x, t, ord)
+classify(x::AbstractMatrix{<:Real}, t::Real) = classify(x, t, Forward)
 
 
 ## label map
@@ -154,7 +154,7 @@ labeldecode(lmap::LabelMap{T}, ys::AbstractArray{Int}) where {T} =
 
 ## group labels
 
-function groupindices(k::Int, xs::IntegerVector; warning::Bool=true)
+function groupindices(k::Int, xs::AbstractVector{<:Integer}; warning::Bool=true)
     gs = Array{Vector{Int}}(undef, k)
     for i = 1:k
         gs[i] = Int[]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -15,7 +15,7 @@ function repeach(x::AbstractVector{T}, n::Integer) where T
     return r
 end
 
-function repeach(x::AbstractVector{T}, ns::IntegerVector) where T
+function repeach(x::AbstractVector{T}, ns::AbstractVector{<:Integer}) where T
     k = length(x)
     length(ns) == k || throw(DimensionMismatch("length(ns) should be equal to k."))
     r = Array{T}(undef, sum(ns))
@@ -46,7 +46,7 @@ function repeachcol(x::DenseArray{T,2}, n::Integer) where T
     return r
 end
 
-function repeachcol(x::DenseArray{T,2}, ns::IntegerVector) where T
+function repeachcol(x::DenseArray{T,2}, ns::AbstractVector{<:Integer}) where T
     m = size(x, 1)
     k = size(x, 2)
     r = zeros(T, m, sum(ns))
@@ -80,7 +80,7 @@ function repeachrow(x::DenseArray{T,2}, n::Integer) where T
     return r
 end
 
-function repeachrow(x::DenseArray{T,2}, ns::IntegerVector) where T
+function repeachrow(x::DenseArray{T,2}, ns::AbstractVector{<:Integer}) where T
     k = size(x, 1)
     m = size(x, 2)
     r = Array{T}(undef, sum(ns), m)


### PR DESCRIPTION
1. StatsBase.jl v0.34 removed some internal array types used by MLBase. This change adds a dependency to NumericalTypeAliases.jl that provides these type aliases.

https://github.com/JuliaStats/StatsBase.jl/pull/840

2. Also adding a CompatHelper action

3. Bumps MLBase version so it can be tagged